### PR TITLE
Disable provenance for built docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,7 @@ jobs:
             ghcr.io/oasisprotocol/rofl-app-backend:latest
             ghcr.io/oasisprotocol/rofl-app-backend:latest-${{ env.VERSION }}
           push: true
+          provenance: false
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,7 @@ jobs:
           tags: |
             ghcr.io/oasisprotocol/rofl-app-backend:${{ env.TAG }}
           push: true
+          provenance: false
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
Fixes issues with prunning: https://github.com/snok/container-retention-policy/issues/63